### PR TITLE
GitHub Action - Marketplace link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ This section includes code libraries in various programming languages which vend
 
 ## Tools
 
-- [GitHub Action](https://github.com/ScottBrenner/aws-cdk-action) for AWS CDK
+- [GitHub Action](https://github.com/marketplace/actions/aws-cdk-action) for AWS CDK
 
 ## Training Materials and Sample Code
 


### PR DESCRIPTION
I fixed my GitHub Action for AWS CDK - it only works for Python projects currently - and published it to the GitHub Marketplace! https://github.com/marketplace/actions/aws-cdk-action