### PR TITLE
Added link to Lambda packaging asset python code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ This section includes code libraries in various programming languages which vend
 - [Infrastructure is Code with the AWS CDK](https://youtu.be/Lh-kVC2r2AU): recording of re:Invent 2018 session
 - [GitHub Changelog Crawler](https://github.com/aws-samples/aws-cdk-changelogs-demo) - a fully fledged CDK app written by Nathan Peck which uses Fargate, API Gateway, Lambda, CloudFront, S3, ElastiCache, and Dynamodb.
 - [ECS with CI/CD](https://github.com/rix0rrr/cdk-ecs-demo)
+- [Lambda packaging asset](https://gitlab.com/josef.stach/aws-cdk-lambda-asset)
 
 ## Blog Posts & Talks
 


### PR DESCRIPTION
This is a Python code for packaging lambda functions with dependencies, library stripping etc. 