### PR TITLE
Add link to example project and guide for AWS CodePipeline and CodeBuild

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ This section includes code libraries in various programming languages which vend
 - [jsii-publish](https://github.com/udondan/jsii-publish): A [Docker image](https://hub.docker.com/r/udondan/jsii-publish) and [GitHub action](https://github.com/marketplace/actions/jsii-publish) to build and publish CDK constructs created via [JSII](https://github.com/aws/jsii).
 
 ## Training Materials and Sample Code
+
 - [Official CDK Examples](https://github.com/aws-samples/aws-cdk-examples)
 - [CDK Serverless Workshop](https://cdkworkshop.com/)
 - [Infrastructure is Code with the AWS CDK](https://youtu.be/Lh-kVC2r2AU): recording of re:Invent 2018 session
@@ -46,6 +47,7 @@ This section includes code libraries in various programming languages which vend
 - [Lambda packaging asset](https://gitlab.com/josef.stach/aws-cdk-lambda-asset)
 - [Open CDK Guide](https://github.com/kevinslin/open-cdk): Open source guide on CDK and best practices
 - [Colorteller Example](https://github.com/denmat/colorteller-aws-cdk): Great example project using Fargate and Appmesh
+- [Create a CI/CD pipeline using CodePipeline and CodeBuild](https://sbstjn.com/deploy-react-cra-with-cdk-codepipeline-and-codebuild.html): The [cra-pipeline](https://github.com/sbstjn/cra-pipeline) project on GitHub shows an AWS CodePipeline with AWS CodeBuild to deploy a static React application
 
 ## Blog Posts & Talks
 


### PR DESCRIPTION
The [cra-pipeline](https://github.com/sbstjn/cra-pipeline) project on GitHub is a full-featured example architecture with AWS CodePipeline and AWS CodeBuild to deploy a [create-react-app](https://create-react-app.dev/) React website. The [tutorial/guide](https://sbstjn.com/deploy-react-cra-with-cdk-codepipeline-and-codebuild.html) walks through all the code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
