### PR TITLE
Add awscdk-jsii-template in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,12 +74,12 @@ This section includes code libraries in various programming languages which vend
 - [ReactJS + Cognito + CDK Starter](https://github.com/vbudilov/reactjs-cognito-starter)
 - [cra-template-aws-cdk](https://github.com/luisfarzati/rnbw-aws-cdk/tree/master/packages/cra-template-aws-cdk) Create React App template using AWS CDK for out of the box, simple provisioning of serverless React apps.
 - [create-cdk-app](https://github.com/cdk-tools/create-cdk-app): Create CDK apps from templates
+- [awscdk-jsii-template](https://github.com/pahud/awscdk-jsii-template) a github template repository to generate a ready environment to build, test and publish your [JSII]((https://github.com/aws/jsii)) construct lib for AWS CDK.
 
 ## Tools
 
 - [GitHub Action](https://github.com/marketplace/actions/aws-cdk-action) for AWS CDK
 - [jsii-publish](https://github.com/udondan/jsii-publish): A [Docker image](https://hub.docker.com/r/udondan/jsii-publish) and [GitHub action](https://github.com/marketplace/actions/jsii-publish) to build and publish CDK constructs created via [JSII](https://github.com/aws/jsii).
-- [awscdk-jsii-template](https://github.com/pahud/awscdk-jsii-template) a github template repository to generate a ready environment to build, test and publish your [JSII]((https://github.com/aws/jsii)) construct lib for AWS CDK.
 
 ## Training Materials and Sample Code
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ This section includes code libraries in various programming languages which vend
 
 - [GitHub Action](https://github.com/marketplace/actions/aws-cdk-action) for AWS CDK
 - [jsii-publish](https://github.com/udondan/jsii-publish): A [Docker image](https://hub.docker.com/r/udondan/jsii-publish) and [GitHub action](https://github.com/marketplace/actions/jsii-publish) to build and publish CDK constructs created via [JSII](https://github.com/aws/jsii).
+- [awscdk-jsii-template](https://github.com/pahud/awscdk-jsii-template) a github template repository to generate a ready environment to build, test and publish your [JSII]((https://github.com/aws/jsii)) construct lib for AWS CDK.
 
 ## Training Materials and Sample Code
 


### PR DESCRIPTION
Add [pahud/awscdk-jsii-template](https://github.com/pahud/awscdk-jsii-template) in the README


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
