### PR TITLE
Added sample code: Django + Vue.js project using CDK

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ This section includes code libraries in various programming languages which vend
 - [Mini Tutorial: Setup AWS Lambda + ACM + API Gateway with AWS Cloud Development Kit](https://github.com/shaftoe/api-gateway-lambda-cdk-example): Deploy a functional public API that receives an HTML form (e.g. /contact_us.html) POST request and delivers its data to Pushover notification service.
 - [Example of REST API built with CDK](https://github.com/shaftoe/api-l3x-in): Source code that powers REST APIs at https://api.l3x.in/
 - [dilbert-feed](https://github.com/mlafeldt/dilbert-feed): A serverless application written in Go that allows you to enjoy Dilbert in your RSS feed reader without any ads.
+- [django-postgres-vue-gitlab-ecs](https://gitlab.com/verbose-equals-true/django-postgres-vue-gitlab-ecs): An example Django + Vue.js web app deployed with CDK using GitLab CI
 
 ## Blog Posts & Talks
 


### PR DESCRIPTION
This is a proof-of-concept project that uses CDK and AWS CLI in GitLab CI to deploy a Django + Vue.js application using the following AWS services:
- Fargate
- CloudFront
- S3
- ALB
- Aurora Postgres Serverless
- ElastiCache
- others

A more thorough description of this project and the technologies used can be found on the project's documentation site: [https://verbose-equals-true.gitlab.io/django-postgres-vue-gitlab-ecs/start/overview/](https://verbose-equals-true.gitlab.io/django-postgres-vue-gitlab-ecs/start/overview/).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
