### PR TITLE
Adding a link to Build an App with AWS CDK course on egghead.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ This section includes code libraries in various programming languages which vend
 
 - [Official CDK Examples](https://github.com/aws-samples/aws-cdk-examples)
 - [CDK Serverless Workshop](https://cdkworkshop.com/)
+- [Build an App with AWS Cloud Development Kit course on egghead.io](https://egghead.io/courses/build-an-app-with-the-aws-cloud-development-kit?af=6p5abz)
 - [Infrastructure is Code with the AWS CDK](https://youtu.be/Lh-kVC2r2AU): recording of re:Invent 2018 session
 - [GitHub Changelog Crawler](https://github.com/aws-samples/aws-cdk-changelogs-demo) - a fully fledged CDK app written by Nathan Peck which uses Fargate, API Gateway, Lambda, CloudFront, S3, ElastiCache, and Dynamodb.
 - [ECS with CI/CD](https://github.com/rix0rrr/cdk-ecs-demo)


### PR DESCRIPTION
A while ago I've published an AWS CDK course on egghead.io and according to initial feedback it's awesome so I hope it belongs on an `awesome-cdk` list!