### PR TITLE
feat: add cdk-self-destruct

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ This section includes code libraries in various programming languages which vend
 
 * [cdk-instanceStopRule](https://github.com/tecracer/cdk-constructs/tree/master/packages/cdk-instanceStopRule) - CDK component which creates an instance with a CloudWatch rule to stop it at the end of the day.
 * [cdk-time-bomb](https://github.com/jmb12686/cdk-time-bomb) - CDK Construct that implodes your AWS CDK Stack after a set amount of time.
+* [cdk-self-destruct](https://github.com/NimmLor/cdk-self-destruct) - Schedule the destruction of CDK Stacks and destroy all associated resources
 
 ### Queue
 


### PR DESCRIPTION
[cdk-self-destruct](https://github.com/NimmLor/cdk-self-destruct) is an utility that enables you to schedule the destruction of cdk stacks while also destroying all associated resources.

It is inspired by [cdk-time-bomb](https://github.com/jmb12686/cdk-time-bomb), but rewritten with aws-cdk v2 and it uses the new [AWS EventBridge Scheduler](https://aws.amazon.com/de/blogs/compute/introducing-amazon-eventbridge-scheduler). 

It also allows you to automatically overwrite the `RemovalPolicy` of every resource in the stack, as well as to delete implicitly created resources or dependencies that prevent the resource from being deleted.

At this time this includes:
- **Purging non-empty S3 buckets** - this would otherwise cause the deployment to fail
- **Cancelling running stepfunction executions** - this would cause the deployment to wait until all executions are finished
- **Deleting log groups created by aws lambda**

## Requirements for your pull request

- Use the following format: `[library](link) - Description.`
- The text of the link should be the name of the package or project.
- If you add a construct published in multiple languages via JSII, the link should point to the source repository, not to npm, PyPI etc
- Add one link per pull-request.
- Keep descriptions concise, clear and simple, and end them with a period / stop.
- New categories, or improvements to the existing ones are also welcome.
- Make sure your text editor is set to remove trailing whitespace.
- It is desirable for the whole thing to fit on one line after getting rendered by GitHub.
