### PR TITLE
feat: add aws-cdk-starterkit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,26 +6,29 @@ The AWS Cloud Development Kit (AWS CDK) is an open-source software development f
 
 ## Contents
 
-* [Construct Libraries](#construct-libraries)
-  * [APIs](#apis)
-  * [Databases](#databases)
-  * [Static Websites](#static-websites)
-  * [Security](#security)
-  * [Ops](#ops)
-  * [Queue](#queue)
-  * [CI/CD](#cicd)
-  * [Monitoring](#monitoring)
-  * [Workflows](#workflows)
-  * [Multi-accounts setup](#multi-accounts-setup)
-* [High-Level Frameworks](#high-level-frameworks)
-* [Scaffolding](#scaffolding)
-* [Language Support](#language-support)
-* [Library Publishing](#library-publishing)
-* [Tools](#tools)
-* [Training Materials and Sample Code](#training-materials-and-sample-code)
-* [Blog Posts & Talks](#blog-posts--talks)
-* [Related Projects](#related-projects)
-* [Tips & Tricks](#tips--tricks)
+- [Awesome CDK  ](#awesome-cdk--)
+  - [Contents](#contents)
+  - [Construct Libraries](#construct-libraries)
+    - [APIs](#apis)
+    - [Databases](#databases)
+    - [Static Websites](#static-websites)
+    - [Security](#security)
+    - [Ops](#ops)
+    - [Queue](#queue)
+    - [CI/CD](#cicd)
+    - [Monitoring](#monitoring)
+    - [Workflows](#workflows)
+    - [Multi-accounts setup](#multi-accounts-setup)
+  - [High-Level Frameworks](#high-level-frameworks)
+  - [Scaffolding](#scaffolding)
+  - [Language Support](#language-support)
+  - [Library Publishing](#library-publishing)
+  - [Tools](#tools)
+  - [Training Materials and Sample Code](#training-materials-and-sample-code)
+  - [Blog Posts \& Talks](#blog-posts--talks)
+  - [Related Projects](#related-projects)
+  - [Tips \& Tricks](#tips--tricks)
+  - [Contributing](#contributing)
 
 ## Construct Libraries
 
@@ -92,7 +95,7 @@ This section includes code libraries in various programming languages which vend
 * [aws-pdf-textract-pipeline](https://github.com/aeksco/aws-pdf-textract-pipeline) - ETL pipeline for crawling PDFs from the Web using Puppeteer and transforming their contents into structured data using AWS Textract and storing the results in DynamoDB.
 
 ### Multi-accounts setup
-* [aws-bootstrap-kit](https://github.com/awslabs/aws-bootstrap-kit) - Creates a multi-account set-up with AWS Organization, AWS SSO, DNS, and AWS CodePipeline.
+* [aws-cdk-starterkit](https://github.com/dannysteenman/aws-cdk-starterkit) - Create and deploy an AWS CDK app on your AWS account in less than 5 minutes using GitHub actions!
 * [cdk-organizations](https://github.com/pepperize/cdk-organizations) - CDK constructs that helps to provision AWS Organization, Organizational Units (OU), Accounts and Policies.
 
 ## High-Level Frameworks
@@ -102,7 +105,7 @@ This section includes code libraries in various programming languages which vend
 * [cdk-stepfunctions-patterns](https://github.com/kolomied/cdk-stepfunctions-patterns) - A set of Step Functions high-level resiliency patterns.
 * [Orkestra](https://github.com/knowsuchagency/orkestra) - An event-driven alternative to Airflow built on the AWS CDK and Step Functions.
 * [SST](https://github.com/serverless-stack/serverless-stack) - An open source framework for building serverless applications with CDK. It features a Live Lambda Development environment, to test and debug Lambda functions locally without having to redeploy them.
-* [Datajob](https://github.com/vincentclaes/datajob) - Build and deploy a serverless data pipeline or machine learning pipeline on AWS with no effort. 
+* [Datajob](https://github.com/vincentclaes/datajob) - Build and deploy a serverless data pipeline or machine learning pipeline on AWS with no effort.
 
 ## Scaffolding
 


### PR DESCRIPTION
The [aws-cdk-starterkit](https://github.com/dannysteenman/aws-cdk-starterkit) is designed to get an AWS CDK app up and running in your AWS account in less than 5 minutes, leveraging GitHub Actions for seamless CI/CD.

**Key Highlights:**

**Rapid Setup**: Enables quick project initialization by modifying just a single configuration file, drastically reducing the initial overhead.
**Multi-Account Flexibility**: Comes enterprise-ready with support for multi-account setups, facilitating scalable and secure cloud environments.
**Automated Deployment Pipelines**: Integrates GitHub Actions workflows out-of-the-box, automating deployments for enhanced efficiency and reliability.
**Structured Project Layout**: Offers a clean and intuitive project structure, simplifying the management of CDK constructs and stacks.
**Seamless Security**: Utilizes OpenID Connect for secure AWS deployments directly from GitHub Actions, negating the need for stored AWS credentials.
**TypeScript and ESLint Preconfiguration**: Comes with pre-set TypeScript compiler options and ESLint setup, promoting best coding practices from the get-go.